### PR TITLE
Fix remaining format string bugs across engines module

### DIFF
--- a/engines/benchmarks/unified_inference_benchmarks.cpp
+++ b/engines/benchmarks/unified_inference_benchmarks.cpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <fstream>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <random>
@@ -152,14 +153,14 @@ struct UnifiedMetrics {
     bool converged;
 
     void print_summary() const {
-        LOG_INFO_PRINT("{} on {}: {:.2f}ms, {:.1f}MB, {} iters, {:.3f} acc, converged={}",
-                       technique_name,
-                       dataset_name,
-                       inference_time_ms,
-                       memory_usage_mb,
-                       convergence_iterations,
-                       final_accuracy,
-                       converged);
+        std::ostringstream oss;
+        oss << technique_name << " on " << dataset_name << ": "
+            << std::fixed << std::setprecision(2) << inference_time_ms << "ms, "
+            << std::setprecision(1) << memory_usage_mb << "MB, "
+            << static_cast<int>(convergence_iterations) << " iters, "
+            << std::setprecision(3) << final_accuracy << " acc, converged="
+            << std::boolalpha << converged;
+        LOG_INFO_PRINT("{}", oss.str());
     }
 };
 

--- a/engines/src/circular_bp/circular_bp.cpp
+++ b/engines/src/circular_bp/circular_bp.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <limits>
 #include <numeric>
 #include <sstream>
@@ -212,14 +213,17 @@ auto CircularBPEngine::run_circular_bp(const GraphicalModel& model)
     metrics_.converged = check_convergence(residual);
 
     if (metrics_.converged) {
-        LOG_INFO_PRINT("Circular-BP converged after {} iterations with residual {:.2e}",
-                       metrics_.iterations_to_convergence,
-                       metrics_.final_residual);
+        std::ostringstream oss;
+        oss << "Circular-BP converged after " << metrics_.iterations_to_convergence 
+            << " iterations with residual " << std::scientific << std::setprecision(2)
+            << metrics_.final_residual;
+        LOG_INFO_PRINT("{}", oss.str());
     } else {
-        LOG_WARNING_PRINT(
-            "Circular-BP failed to converge after {} iterations, final residual: {:.2e}",
-            metrics_.iterations_to_convergence,
-            metrics_.final_residual);
+        std::ostringstream oss;
+        oss << "Circular-BP failed to converge after " << metrics_.iterations_to_convergence 
+            << " iterations, final residual: " << std::scientific << std::setprecision(2)
+            << metrics_.final_residual;
+        LOG_WARNING_PRINT("{}", oss.str());
     }
     LOG_DEBUG_PRINT(
         "Inference completed in {}ms with {} cycles detected, {} correlations cancelled",
@@ -555,8 +559,10 @@ auto CircularBPEngine::cancel_spurious_correlations(GraphicalModel& model)
                 }
 
                 cancelled_count++;
-                LOG_DEBUG_PRINT(
-                    "Cancelled spurious correlation {:.3f} on edge {}", correlation, edge_id);
+                std::ostringstream oss;
+                oss << "Cancelled spurious correlation " << std::fixed << std::setprecision(3) 
+                    << correlation << " on edge " << edge_id;
+                LOG_DEBUG_PRINT("{}", oss.str());
             }
         }
     }

--- a/engines/src/mamba_ssm/mamba_ssm.cpp
+++ b/engines/src/mamba_ssm/mamba_ssm.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 // Platform-specific SIMD includes
 #if defined(__x86_64__) || defined(_M_X64)
     #include <immintrin.h>  // For AVX2 SIMD operations on x86_64
@@ -458,9 +459,11 @@ auto MambaSSMEngine::run_mamba_ssm(const FloatTensor& input_sequence)
     metrics_.throughput_tokens_per_sec =
         static_cast<double>(seq_len) / (metrics_.inference_time_ms.count() / 1000000.0);
 
-    LOG_INFO_PRINT("Mamba SSM inference completed in {}μs with throughput {:.1f} tokens/sec",
-                   metrics_.inference_time_ms.count(),
-                   metrics_.throughput_tokens_per_sec);
+    std::ostringstream oss;
+    oss << "Mamba SSM inference completed in " << metrics_.inference_time_ms.count() 
+        << "μs with throughput " << std::fixed << std::setprecision(1) 
+        << metrics_.throughput_tokens_per_sec << " tokens/sec";
+    LOG_INFO_PRINT("{}", oss.str());
 
     return Ok(std::move(output));
 }

--- a/engines/src/momentum_bp/momentum_bp.cpp
+++ b/engines/src/momentum_bp/momentum_bp.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <numeric>
 #include <sstream>
 
@@ -168,14 +169,17 @@ auto MomentumBPEngine::run_momentum_bp(const GraphicalModel& model)
     metrics_.converged = check_convergence(residual);
 
     if (metrics_.converged) {
-        LOG_INFO_PRINT("Momentum-BP converged after {} iterations with residual {:.2e}",
-                       metrics_.iterations_to_convergence,
-                       metrics_.final_residual);
+        std::ostringstream oss;
+        oss << "Momentum-BP converged after " << metrics_.iterations_to_convergence 
+            << " iterations with residual " << std::scientific << std::setprecision(2)
+            << metrics_.final_residual;
+        LOG_INFO_PRINT("{}", oss.str());
     } else {
-        LOG_WARNING_PRINT(
-            "Momentum-BP failed to converge after {} iterations, final residual: {:.2e}",
-            metrics_.iterations_to_convergence,
-            metrics_.final_residual);
+        std::ostringstream oss;
+        oss << "Momentum-BP failed to converge after " << metrics_.iterations_to_convergence 
+            << " iterations, final residual: " << std::scientific << std::setprecision(2)
+            << metrics_.final_residual;
+        LOG_WARNING_PRINT("{}", oss.str());
     }
     LOG_DEBUG_PRINT("Inference completed in {}ms with {} message updates",
                     metrics_.inference_time_ms.count(),

--- a/engines/tests/test_engines_comprehensive.cpp
+++ b/engines/tests/test_engines_comprehensive.cpp
@@ -27,7 +27,9 @@
  */
 
 #include <chrono>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -472,9 +474,11 @@ TEST_F(EnginesComprehensiveTest, PerformanceUnderLoad) {
     ASSERT_NE(mock_engine, nullptr);
     EXPECT_EQ(mock_engine->get_inference_count(), NUM_ITERATIONS);
 
-    LOG_INFO_PRINT("Performance test: {:.2f}μs avg, {:.1f} inferences/sec",
-                   avg_time_us,
-                   throughput_inferences_per_sec);
+    std::ostringstream oss;
+    oss << "Performance test: " << std::fixed << std::setprecision(2) << avg_time_us 
+        << "μs avg, " << std::setprecision(1) << throughput_inferences_per_sec 
+        << " inferences/sec";
+    LOG_INFO_PRINT("{}", oss.str());
 }
 
 /**

--- a/engines/tests/test_inference_engine.cpp
+++ b/engines/tests/test_inference_engine.cpp
@@ -20,7 +20,9 @@
  * - Memory safety validation with sanitizers
  */
 
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -285,5 +287,8 @@ TEST_F(InferenceEngineTest, MockEnginePerformance) {
     // Mock engine should be very fast (< 100 microseconds per inference)
     EXPECT_LT(avg_time_us, 100.0) << true;
 
-    LOG_INFO_PRINT("Mock engine average inference time: {:.2f} microseconds", avg_time_us);
+    std::ostringstream oss;
+    oss << "Mock engine average inference time: " << std::fixed << std::setprecision(2) 
+        << avg_time_us << " microseconds";
+    LOG_INFO_PRINT("{}", oss.str());
 }


### PR DESCRIPTION
## Summary
Fixed all remaining format string bugs across the engines module where advanced format specifiers like `{:.2f}`, `{:.3f}`, and `{:.2e}` were being printed literally instead of formatting the values.

## Problems Fixed
The logging system only supports simple `{}` placeholder replacement and doesn't support advanced format specifiers. This was causing output like:
```
Mamba SSM inference completed in 3143μs with throughput {:.1f} tokens/sec
Circular-BP converged after 2 iterations with residual {:.2e}
Cancelled spurious correlation {:.3f} on edge 1
```

## Files Changed
- **engines/src/mamba_ssm/mamba_ssm.cpp**: Fixed throughput formatting (`{:.1f}`)
- **engines/src/circular_bp/circular_bp.cpp**: Fixed residual (`{:.2e}`) and correlation (`{:.3f}`) formatting
- **engines/src/momentum_bp/momentum_bp.cpp**: Fixed convergence residual formatting (`{:.2e}`)
- **engines/tests/test_inference_engine.cpp**: Fixed timing formatting (`{:.2f}`)
- **engines/tests/test_engines_comprehensive.cpp**: Fixed performance formatting (`{:.2f}` and `{:.1f}`)
- **engines/benchmarks/unified_inference_benchmarks.cpp**: Fixed summary formatting (multiple specifiers)

## Solution
Replaced all advanced format specifiers with manual `std::ostringstream` formatting using:
- `std::setprecision()` for decimal places
- `std::fixed` for fixed-point notation
- `std::scientific` for scientific notation
- `std::boolalpha` for boolean formatting

Added `#include <iomanip>` where needed for formatting functions.

## Test Results
✅ Verified with actual demo runs that output now shows:
```
Mamba SSM inference completed in 3143μs with throughput 21347.6 tokens/sec
Circular-BP converged after 2 iterations with residual 0.00e+00
Cancelled spurious correlation 1.000 on edge 1
```

## Related
- Related to PR #23 which fixed the same issue in `unified_inference_benchmarks.cpp`
- This PR completes the fix for all remaining instances across the engines module

🤖 Generated with [Claude Code](https://claude.ai/code)